### PR TITLE
Fix/p2p grpc error

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -916,11 +916,12 @@
   version = "v1.0.2"
 
 [[projects]]
-  digest = "1:c678fc5e480693538ca4318aedaa4bd3e6685db9ad9b012fadb6655c112777a7"
+  digest = "1:317c23d0134d82f8158538d6d61ec0b5425319bcd6af716cda898636e51fb757"
   name = "github.com/paralin/go-libp2p-grpc"
   packages = ["."]
   pruneopts = "UT"
-  revision = "3d5d33466aef613c8ed7992fe35987b34245424e"
+  revision = "04711f07389ecbca09d7999474dda4a88c955c73"
+  source = "git@github.com:vedhavyas/go-libp2p-grpc.git"
 
 [[projects]]
   digest = "1:e5d0bd87abc2781d14e274807a470acd180f0499f8bf5bb18606e9ec22ad9de9"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -222,7 +222,8 @@ required = ["github.com/centrifuge/centrifuge-ethereum-contracts", "github.com/r
 
 [[constraint]]
   name = "github.com/paralin/go-libp2p-grpc"
-  revision = "3d5d33466aef613c8ed7992fe35987b34245424e"
+  source = "git@github.com:vedhavyas/go-libp2p-grpc.git"
+  revision = "04711f07389ecbca09d7999474dda4a88c955c73"
 
 [[constraint]]
   name = "github.com/spf13/cobra"


### PR DESCRIPTION
Fixes #281 

Its too annoying to restart the builds and develop seems to fail almost everytime due to this. I pushed a fix to upstream. Until the [PR](https://github.com/paralin/go-libp2p-grpc/pull/1) is accepted there using my fork as the source.

Once upstream accepts the PR, we can use that in the dep