### PR TITLE
fix bug in rendering attributes

### DIFF
--- a/httpapi/coreapi/types.go
+++ b/httpapi/coreapi/types.go
@@ -170,35 +170,36 @@ func convertNFTs(tokenRegistry documents.TokenRegistry, nfts []*coredocumentpb.N
 func toAttributeMapResponse(attrs []documents.Attribute) (AttributeMapResponse, error) {
 	m := make(AttributeMapResponse)
 	for _, v := range attrs {
+		vx := v // convert to value
 		var attrReq AttributeRequest
-		switch v.Value.Type {
+		switch vx.Value.Type {
 		case documents.AttrMonetary:
-			id := string(v.Value.Monetary.ID)
-			if v.Value.Monetary.Type == documents.MonetaryToken {
-				id = hexutil.Encode(v.Value.Monetary.ID)
+			id := string(vx.Value.Monetary.ID)
+			if vx.Value.Monetary.Type == documents.MonetaryToken {
+				id = hexutil.Encode(vx.Value.Monetary.ID)
 			}
 			attrReq = AttributeRequest{
-				Type: v.Value.Type.String(),
+				Type: vx.Value.Type.String(),
 				MonetaryValue: &MonetaryValue{
-					Value:   v.Value.Monetary.Value,
-					ChainID: v.Value.Monetary.ChainID,
+					Value:   vx.Value.Monetary.Value,
+					ChainID: vx.Value.Monetary.ChainID,
 					ID:      id,
 				},
 			}
 		default:
-			val, err := v.Value.String()
+			val, err := vx.Value.String()
 			if err != nil {
 				return nil, err
 			}
 			attrReq = AttributeRequest{
-				Type:  v.Value.Type.String(),
+				Type:  vx.Value.Type.String(),
 				Value: val,
 			}
 		}
 
-		m[v.KeyLabel] = AttributeResponse{
+		m[vx.KeyLabel] = AttributeResponse{
 			AttributeRequest: attrReq,
-			Key:              v.Key[:],
+			Key:              vx.Key[:],
 		}
 	}
 

--- a/httpapi/coreapi/types_test.go
+++ b/httpapi/coreapi/types_test.go
@@ -60,6 +60,7 @@ func TestTypes_toAttributeMapResponse(t *testing.T) {
 	assert.Equal(t, cattrs["string_test"].Value, attrs["string_test"].Value)
 	assert.Equal(t, cattrs["decimal_test"].Value, attrs["decimal_test"].Value)
 	assert.Equal(t, cattrs["monetary_test"].MonetaryValue, attrs["monetary_test"].MonetaryValue)
+	assert.NotEqual(t, cattrs["string_test"].Key.String(), cattrs["decimal_test"].Key.String())
 
 	attrs["monetary_test_empty"] = AttributeRequest{Type: "monetary"}
 	_, err = toDocumentAttributes(attrs)


### PR DESCRIPTION
We had a problem rendering the attributes back to JSON. Since we were not making a copy of the value, then a pointer was used and all keys appear with the same key value as the last property.