### PR TITLE
Update build directives as per Go 1.18 release notes

### DIFF
--- a/anchors/anchor_test.go
+++ b/anchors/anchor_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package anchors
 

--- a/anchors/mocks.go
+++ b/anchors/mocks.go
@@ -1,4 +1,4 @@
-// +build integration unit testworld
+//go:build integration || unit || testworld
 
 package anchors
 

--- a/anchors/service_integration_test.go
+++ b/anchors/service_integration_test.go
@@ -1,4 +1,4 @@
-// +build integration
+//go:build integration
 
 package anchors
 

--- a/bootstrap/bootstrappers/bootstrapper_test.go
+++ b/bootstrap/bootstrappers/bootstrapper_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package bootstrappers
 

--- a/bootstrap/test_bootstrapper.go
+++ b/bootstrap/test_bootstrapper.go
@@ -1,4 +1,4 @@
-// +build integration unit
+//go:build integration || unit
 
 package bootstrap
 

--- a/centchain/api_integration_test.go
+++ b/centchain/api_integration_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package centchain_test
 

--- a/centchain/api_test.go
+++ b/centchain/api_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package centchain
 

--- a/centchain/mocks.go
+++ b/centchain/mocks.go
@@ -1,5 +1,4 @@
 //go:build unit || integration
-// +build unit integration
 
 package centchain
 

--- a/cmd/centrifuge/create_config_test.go
+++ b/cmd/centrifuge/create_config_test.go
@@ -1,4 +1,4 @@
-// +build cmd
+//go:build cmd
 
 package main
 

--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package cmd
 

--- a/config/configstore/accounts_test.go
+++ b/config/configstore/accounts_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package configstore
 

--- a/config/configstore/bootstrapper_test.go
+++ b/config/configstore/bootstrapper_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package configstore
 

--- a/config/configstore/mocks.go
+++ b/config/configstore/mocks.go
@@ -1,4 +1,4 @@
-// +build unit integration testworld
+//go:build unit || integration || testworld
 
 package configstore
 

--- a/config/configstore/repository_test.go
+++ b/config/configstore/repository_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package configstore
 

--- a/config/configstore/service_integration_test.go
+++ b/config/configstore/service_integration_test.go
@@ -1,4 +1,4 @@
-// +build integration
+//go:build integration
 
 package configstore_test
 

--- a/config/configstore/service_test.go
+++ b/config/configstore/service_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package configstore
 

--- a/config/configuration_test.go
+++ b/config/configuration_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package config
 

--- a/config/mocks.go
+++ b/config/mocks.go
@@ -1,5 +1,4 @@
 //go:build integration || unit
-// +build integration unit
 
 package config
 

--- a/contextutil/context_test.go
+++ b/contextutil/context_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package contextutil
 

--- a/crypto/ed25519/ed25519_test.go
+++ b/crypto/ed25519/ed25519_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package ed25519
 

--- a/crypto/generate_test.go
+++ b/crypto/generate_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package crypto
 

--- a/crypto/secp256k1/secp256k1_test.go
+++ b/crypto/secp256k1/secp256k1_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package secp256k1
 

--- a/crypto/sign_test.go
+++ b/crypto/sign_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package crypto
 

--- a/crypto/verify_test.go
+++ b/crypto/verify_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package crypto
 

--- a/documents/attribute_test.go
+++ b/documents/attribute_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package documents
 

--- a/documents/bootstrapper_test.go
+++ b/documents/bootstrapper_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package documents
 

--- a/documents/compute_fields_test.go
+++ b/documents/compute_fields_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package documents
 

--- a/documents/converters_test.go
+++ b/documents/converters_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package documents
 

--- a/documents/coredocument_test.go
+++ b/documents/coredocument_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package documents
 

--- a/documents/decimal_test.go
+++ b/documents/decimal_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package documents
 

--- a/documents/entity/converters_test.go
+++ b/documents/entity/converters_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package entity
 

--- a/documents/entity/mocks.go
+++ b/documents/entity/mocks.go
@@ -1,4 +1,4 @@
-// +build integration unit testworld
+//go:build integration || unit || testworld
 
 package entity
 

--- a/documents/entity/model_test.go
+++ b/documents/entity/model_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package entity
 

--- a/documents/entity/service_test.go
+++ b/documents/entity/service_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package entity
 

--- a/documents/entity/validator_test.go
+++ b/documents/entity/validator_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package entity
 

--- a/documents/entityrelationship/mocks.go
+++ b/documents/entityrelationship/mocks.go
@@ -1,4 +1,4 @@
-// +build integration unit testworld
+//go:build integration || unit || testworld
 
 package entityrelationship
 

--- a/documents/entityrelationship/model_test.go
+++ b/documents/entityrelationship/model_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package entityrelationship
 

--- a/documents/entityrelationship/repository_test.go
+++ b/documents/entityrelationship/repository_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package entityrelationship
 

--- a/documents/entityrelationship/service_test.go
+++ b/documents/entityrelationship/service_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package entityrelationship
 

--- a/documents/entityrelationship/validator_test.go
+++ b/documents/entityrelationship/validator_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package entityrelationship
 

--- a/documents/generic/mocks.go
+++ b/documents/generic/mocks.go
@@ -1,4 +1,4 @@
-// +build integration unit testworld
+//go:build integration || unit || testworld
 
 package generic
 

--- a/documents/generic/model_test.go
+++ b/documents/generic/model_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package generic
 

--- a/documents/generic/service_test.go
+++ b/documents/generic/service_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package generic
 

--- a/documents/mocks.go
+++ b/documents/mocks.go
@@ -1,4 +1,4 @@
-// +build integration unit testworld
+//go:build integration || unit || testworld
 
 package documents
 

--- a/documents/processor_test.go
+++ b/documents/processor_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package documents
 

--- a/documents/read_acls_test.go
+++ b/documents/read_acls_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package documents
 

--- a/documents/registry_test.go
+++ b/documents/registry_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package documents_test
 

--- a/documents/repository_test.go
+++ b/documents/repository_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package documents
 

--- a/documents/service_test.go
+++ b/documents/service_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package documents
 

--- a/documents/types_test.go
+++ b/documents/types_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package documents
 

--- a/documents/validator_test.go
+++ b/documents/validator_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package documents
 

--- a/documents/write_acls_test.go
+++ b/documents/write_acls_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package documents
 

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package errors
 

--- a/ethereum/geth_client_integration_test.go
+++ b/ethereum/geth_client_integration_test.go
@@ -1,4 +1,4 @@
-// +build integration
+//go:build integration
 
 package ethereum_test
 

--- a/ethereum/geth_client_test.go
+++ b/ethereum/geth_client_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package ethereum
 

--- a/ethereum/mocks.go
+++ b/ethereum/mocks.go
@@ -1,4 +1,4 @@
-// +build integration unit
+//go:build integration || unit
 
 package ethereum
 

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,6 @@ require (
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 	github.com/whyrusleeping/go-logging v0.0.1
 	golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871
-	golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2
 	google.golang.org/grpc v1.40.0
 )
 
@@ -239,6 +238,7 @@ require (
 	go.uber.org/multierr v1.7.0 // indirect
 	go.uber.org/zap v1.19.1 // indirect
 	golang.org/x/mod v0.4.2 // indirect
+	golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20211124211545-fe61309f8881 // indirect
 	golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf // indirect

--- a/http/bootstrapper_test.go
+++ b/http/bootstrapper_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package http
 

--- a/http/coreapi/types_test.go
+++ b/http/coreapi/types_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package coreapi
 

--- a/http/health/health_test.go
+++ b/http/health/health_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package health
 

--- a/http/mocks.go
+++ b/http/mocks.go
@@ -1,4 +1,4 @@
-// +build unit integration
+//go:build unit || integration
 
 package http
 

--- a/http/router_test.go
+++ b/http/router_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package http
 

--- a/http/server.go
+++ b/http/server.go
@@ -6,10 +6,10 @@ import (
 	"sync"
 	"time"
 
+	"context"
 	"github.com/centrifuge/go-centrifuge/utils/httputils"
 	"github.com/go-chi/render"
 	logging "github.com/ipfs/go-log"
-	"golang.org/x/net/context"
 )
 
 var log = logging.Logger("api-server")

--- a/http/server_test.go
+++ b/http/server_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package http
 

--- a/http/v2/accounts_api_test.go
+++ b/http/v2/accounts_api_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package v2
 

--- a/http/v2/attribute_api_test.go
+++ b/http/v2/attribute_api_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package v2
 

--- a/http/v2/bootstrapper_test.go
+++ b/http/v2/bootstrapper_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package v2
 

--- a/http/v2/documents_api_test.go
+++ b/http/v2/documents_api_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package v2
 

--- a/http/v2/entity_api_test.go
+++ b/http/v2/entity_api_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package v2
 

--- a/http/v2/handler_test.go
+++ b/http/v2/handler_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package v2
 

--- a/http/v2/jobs_api_test.go
+++ b/http/v2/jobs_api_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package v2
 

--- a/http/v2/mocks.go
+++ b/http/v2/mocks.go
@@ -1,4 +1,4 @@
-// +build unit integration
+//go:build unit || integration
 
 package v2
 

--- a/http/v2/nfts_api_beta_test.go
+++ b/http/v2/nfts_api_beta_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package v2
 

--- a/http/v2/nfts_api_test.go
+++ b/http/v2/nfts_api_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package v2
 

--- a/http/v2/roles_test.go
+++ b/http/v2/roles_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package v2
 

--- a/http/v2/rules_test.go
+++ b/http/v2/rules_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package v2
 

--- a/identity/converters_test.go
+++ b/identity/converters_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package identity
 

--- a/identity/did_test.go
+++ b/identity/did_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package identity
 

--- a/identity/ideth/bootstrapper_test.go
+++ b/identity/ideth/bootstrapper_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package ideth
 

--- a/identity/ideth/factory_integration_test.go
+++ b/identity/ideth/factory_integration_test.go
@@ -1,4 +1,4 @@
-// +build integration
+//go:build integration
 
 package ideth
 

--- a/identity/ideth/mocks.go
+++ b/identity/ideth/mocks.go
@@ -1,4 +1,4 @@
-// +build integration unit testworld
+//go:build integration || unit || testworld
 
 package ideth
 

--- a/identity/ideth/service_integration_test.go
+++ b/identity/ideth/service_integration_test.go
@@ -1,4 +1,4 @@
-// +build integration
+//go:build integration
 
 package ideth
 

--- a/identity/mocks.go
+++ b/identity/mocks.go
@@ -1,4 +1,4 @@
-// +build unit integration testworld
+//go:build unit || integration || testworld
 
 package identity
 

--- a/jobs/jobs_test.go
+++ b/jobs/jobs_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package jobs
 

--- a/jobs/mocks.go
+++ b/jobs/mocks.go
@@ -1,4 +1,4 @@
-// +build unit integration
+//go:build unit || integration
 
 package jobs
 

--- a/migration/files/04AddStatusToDocuments_test.go
+++ b/migration/files/04AddStatusToDocuments_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package migrationfiles
 

--- a/nft/bootstrapper_test.go
+++ b/nft/bootstrapper_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package nft
 

--- a/nft/chain_api_test.go
+++ b/nft/chain_api_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package nft
 

--- a/nft/mocks.go
+++ b/nft/mocks.go
@@ -1,4 +1,4 @@
-// +build integration unit testworld
+//go:build integration || unit || testworld
 
 package nft
 

--- a/nft/service_integration_test.go
+++ b/nft/service_integration_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package nft_test
 

--- a/nft/service_test.go
+++ b/nft/service_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package nft
 

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package node
 

--- a/notification/notification_test.go
+++ b/notification/notification_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package notification
 

--- a/oracle/mocks.go
+++ b/oracle/mocks.go
@@ -1,4 +1,4 @@
-// +build integration unit testworld
+//go:build integration || unit || testworld
 
 package oracle
 

--- a/p2p/bootstrapper_test.go
+++ b/p2p/bootstrapper_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package p2p
 

--- a/p2p/client_integration_test.go
+++ b/p2p/client_integration_test.go
@@ -1,4 +1,4 @@
-// +build integration
+//go:build integration
 
 package p2p_test
 

--- a/p2p/client_test.go
+++ b/p2p/client_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package p2p
 

--- a/p2p/common/mocks.go
+++ b/p2p/common/mocks.go
@@ -1,4 +1,4 @@
-// +build unit integration testworld
+//go:build unit || integration || testworld
 
 package p2pcommon
 

--- a/p2p/common/protocol_test.go
+++ b/p2p/common/protocol_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package p2pcommon
 

--- a/p2p/messenger/messenger_test.go
+++ b/p2p/messenger/messenger_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package messenger
 

--- a/p2p/mocks.go
+++ b/p2p/mocks.go
@@ -1,4 +1,4 @@
-// +build unit integration testworld
+//go:build unit || integration || testworld
 
 package p2p
 

--- a/p2p/receiver/handler_integration_test.go
+++ b/p2p/receiver/handler_integration_test.go
@@ -1,4 +1,4 @@
-// +build integration
+//go:build integration
 
 package receiver_test
 

--- a/p2p/receiver/handler_test.go
+++ b/p2p/receiver/handler_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package receiver
 

--- a/p2p/receiver/validator_test.go
+++ b/p2p/receiver/validator_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package receiver
 

--- a/p2p/server_test.go
+++ b/p2p/server_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package p2p
 

--- a/pending/bootstrapper_test.go
+++ b/pending/bootstrapper_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package pending
 

--- a/pending/mocks.go
+++ b/pending/mocks.go
@@ -1,4 +1,4 @@
-// +build integration unit
+//go:build integration || unit
 
 package pending
 

--- a/pending/repository_test.go
+++ b/pending/repository_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package pending
 

--- a/pending/service_test.go
+++ b/pending/service_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package pending
 

--- a/storage/leveldb/bootstrapper_test.go
+++ b/storage/leveldb/bootstrapper_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package leveldb
 

--- a/storage/leveldb/leveldb_test.go
+++ b/storage/leveldb/leveldb_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package leveldb
 

--- a/storage/leveldb/mocks.go
+++ b/storage/leveldb/mocks.go
@@ -1,4 +1,4 @@
-// +build integration unit
+//go:build integration || unit
 
 package leveldb
 

--- a/utils/byteutils/bytes_test.go
+++ b/utils/byteutils/bytes_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package byteutils
 

--- a/utils/events_test.go
+++ b/utils/events_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package utils
 

--- a/utils/httputils/utils_test.go
+++ b/utils/httputils/utils_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package httputils
 

--- a/utils/httputils_test.go
+++ b/utils/httputils_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package utils
 

--- a/utils/io_test.go
+++ b/utils/io_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package utils
 

--- a/utils/log_test.go
+++ b/utils/log_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package utils
 

--- a/utils/strings_test.go
+++ b/utils/strings_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package utils
 

--- a/utils/stringutils/utils_test.go
+++ b/utils/stringutils/utils_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package stringutils
 

--- a/utils/time_test.go
+++ b/utils/time_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package utils
 

--- a/utils/tools_test.go
+++ b/utils/tools_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//go:build unit
 
 package utils
 


### PR DESCRIPTION
Go 1.17 introduced //go:build lines as a more readable way to write build constraints, instead of // +build lines. As of Go 1.17, gofmt adds //go:build lines to match existing +build lines and keeps them in sync, while go vet diagnoses when they are out of sync.

Since the release of Go 1.18 marks the end of support for Go 1.16, all supported versions of Go now understand //go:build lines. In Go 1.18, go fix now removes the now-obsolete // +build lines in modules declaring go 1.18 or later in their go.mod files.

For more information, see https://go.dev/design/draft-gobuild.